### PR TITLE
now support YYYY/MM/dd in track command

### DIFF
--- a/temp.go
+++ b/temp.go
@@ -214,7 +214,7 @@ func handleBotCommands(replyChannel chan ReplyChannel) {
 			replyChannel <- reply
 		case "track":
 			if len(commandArray) < 3 {
-				reply.DisplayTitle = "Sorry, I don't have enough information to make an event for you. try `@togglbot track PROJECT_NAME 9:00AM-5:00PM TASK_DESCRIPTION`"
+				reply.DisplayTitle = "Sorry, I don't have enough information to make an event for you. try `@togglbot track PROJECT_NAME 9:00AM-5:00PM YYYY/MM/DD (or 'today') TASK_DESCRIPTION`"
 				replyChannel <- reply
 				break
 			}
@@ -222,7 +222,7 @@ func handleBotCommands(replyChannel chan ReplyChannel) {
 			pid := getProjectWithName(togglApiKey, projectName)
 			timeRange := commandArray[2]
 
-			parsedDate := parseDate(commandArray[3])
+			parsedDate, err := parseDate(commandArray[3])
 
 			description := "no description provided"
 			if len(commandArray) > 4 {
@@ -246,7 +246,10 @@ func handleBotCommands(replyChannel chan ReplyChannel) {
 }
 
 func parseDate(readingDate string) (*time.Date, error) {
-	parsedDate, err := time.Parse("2006/01/02", readingDate)
+	if strings.ToLower(readingDate) == "today" {
+		return nil, nil
+	}
+	parsedDate, err := time.Parse("2006/1/2", readingDate)
 	if err != nil {
 		return nil, errors.New("Your date is incorrectly formatted! Try something like: 2017/08/11. The ISO 8601 Standard 😉")
 	}

--- a/temp.go
+++ b/temp.go
@@ -26,7 +26,7 @@ func pingTogglApi(apiKey string) error {
 	ts := toggl.OpenSession(apiKey)
 	_, err := ts.GetAccount()
 	if err != nil {
-		fmt.Println(os.Stderr, "Error: %s\n", err)	
+		fmt.Println(os.Stderr, "Error: %s\n", err)
 		return err
 	}
 	return nil

--- a/temp.go
+++ b/temp.go
@@ -247,14 +247,14 @@ func handleBotCommands(replyChannel chan ReplyChannel) {
 
 func parseDate(readingDate string) (*time.Date, error) {
 	if strings.ToLower(readingDate) == "today" {
-		return nil, nil
+		return time.Now(), nil
 	}
 	parsedDate, err := time.Parse("2006/1/2", readingDate)
 	if err != nil {
 		return nil, errors.New("Your date is incorrectly formatted! Try something like: 2017/08/11. The ISO 8601 Standard 😉")
 	}
 
-	return parsedDate
+	return parsedDate, nil
 }
 
 func parseTimeRange(timeRange string, parsedDate time.Date) (*time.Time, *time.Duration, error) {


### PR DESCRIPTION
Now can submit a track command that looks like this:
@togglbot track breatheagain 9:00AM-5:00PM 2017/08/05 BAS-79
or
@togglbot track breatheagain 9:00AM-5:00PM 2017/8/5 BAS-79
or if for today
@togglbot track breatheagain 9:00AM-5:00PM today BAS-79

either date (YYYY/MM/dd) or "today" must be inserted for track command